### PR TITLE
adding workaround for the EmptyResponse error so we only see it if op…

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -159,14 +159,14 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
         this.sync(options)
           .select()
           .bind(this)
-          .tap(function(response) {
-            if (!response || response.length === 0) {
-              throw new this.constructor.EmptyError('EmptyResponse');
-            }
-          })
-
+          
           // Now, load all of the data onto the collection as necessary.
           .tap(function(response) {
+            if (!response || response.length === 0) {
+              if (options.require === true) {
+                throw new this.constructor.NotFoundError('EmptyResponse');
+              } else return;
+            }
             return this._handleResponse(response, options);
           })
 
@@ -175,6 +175,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
           // next step of the collection. Since the `columns` are only relevant to the current
           // level, ensure those are omitted from the options.
           .tap(function(response) {
+            if (!response || response.length === 0) return;
             if (options.withRelated) {
               return this._handleEager(response, _.omit(options, 'columns'));
             }
@@ -193,6 +194,10 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
              * @param {Object} options Options object passed to {@link Collection#fetch fetch}.
              * @returns {Promise}
              */
+              if (!response || response.length === 0) {
+                this.reset([], {silent: true});
+              return;
+            }
             return this.triggerThen('fetched', this, response, options);
           })
           .catch(this.constructor.EmptyError, function(err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -713,21 +713,22 @@ const BookshelfModel = ModelBase.extend(
           .first(attributes)
           .bind(this)
 
-          // Jump the rest of the chain if the response doesn't exist...
+          // Now, load all of the data into the model as necessary.
           .tap(function(response) {
             if (!response || response.length === 0) {
-              throw new this.constructor.NotFoundError('EmptyResponse');
+              if (options.require === true) {
+                throw new this.constructor.NotFoundError('EmptyResponse');
+              } else return;
             }
+            return this._handleResponse(response, options);
           })
-
-          // Now, load all of the data into the model as necessary.
-          .tap(this._handleResponse)
 
           // If the "withRelated" is specified, we also need to eager load all of the
           // data on the model, as a side-effect, before we ultimately jump into the
           // next step of the model. Since the `columns` are only relevant to the
           // current level, ensure those are omitted from the options.
           .tap(function(response) {
+            if (!response || response.length === 0) return;
             if (options.withRelated) {
               return this._handleEager(response, _.omit(options, 'columns'));
             }
@@ -750,6 +751,7 @@ const BookshelfModel = ModelBase.extend(
              *   If the handler returns a promise, `fetch` will wait for it to
              *   be resolved.
              */
+            if (!response || response.length === 0) return null;
             if (!options.silent) return this.triggerThen('fetched', this, response, options);
           })
           .return(this)


### PR DESCRIPTION

Bookshelf is currently throwing a customError that is EmptyResponse VERY frequently. It was decided to fork bookshelf and make the changes to bookshelf directly. We are currently trying to get off of bookshelf, so this is some what of a low risk change. I don't believe we have any intention, at this time, of merging these changes into bookshelf, they are purely related to our project.

Added checks so that we only throw the error if options.require is set to true and returning the correct items at the end. 